### PR TITLE
Access tokens for multiple forge instances

### DIFF
--- a/doc/manual/generate-options.nix
+++ b/doc/manual/generate-options.nix
@@ -13,7 +13,12 @@ concatStrings (map
       then "*empty*"
       else if isBool option.value
       then (if option.value then "`true`" else "`false`")
-      else "`" + toString option.value + "`") + "\n\n"
+      else
+        # n.b. a StringMap value type is specified as a string, but
+        # this shows the value type.  The empty stringmap is "null" in
+        # JSON, but that converts to "{ }" here.
+        (if isAttrs option.value then "`\"\"`"
+         else "`" + toString option.value + "`")) + "\n\n"
     + (if option.aliases != []
        then "    **Deprecated alias:** " + (concatStringsSep ", " (map (s: "`${s}`") option.aliases)) + "\n\n"
        else "")

--- a/src/libfetchers/github.cc
+++ b/src/libfetchers/github.cc
@@ -146,7 +146,17 @@ struct GitArchiveInputScheme : InputScheme
         auto tokens = settings.accessTokens.get();
         auto pat = tokens.find(host);
         if (pat == tokens.end())
+        {
+            if ("github.com" == host)
+            {
+                auto oldcfg = settings.githubAccessToken.get();
+                if (!oldcfg.empty()) {
+                    warn("using deprecated 'github-access-token' config value; please use 'access-tokens' instead");
+                    return oldcfg;
+                }
+            }
             return std::nullopt;
+        }
         return pat->second;
     }
 

--- a/src/libstore/globals.hh
+++ b/src/libstore/globals.hh
@@ -863,8 +863,54 @@ public:
     Setting<std::string> githubAccessToken{this, "", "github-access-token",
         "GitHub access token to get access to GitHub data through the GitHub API for `github:<..>` flakes."};
 
-    Setting<std::string> gitlabAccessToken{this, "", "gitlab-access-token",
-        "GitLab access token to get access to GitLab data through the GitLab API for gitlab:<..> flakes."};
+    Setting<StringMap> accessTokens{this, {}, "access-tokens",
+        R"(
+          Access tokens used to access protected GitHub, GitLab, or
+          other locations requiring token-based authentication.
+
+          Access tokens are specified as a string made up of
+          space-separated `host=token` values.  The specific token
+          used is selected by matching the `host` portion against the
+          "host" specification of the input. The actual use of the
+          `token` value is determined by the type of resource being
+          accessed:
+
+          * Github: the token value is the OAUTH-TOKEN string obtained
+            as the Personal Access Token from the Github server (see
+            https://docs.github.com/en/developers/apps/authorizing-oath-apps).
+
+          * Gitlab: the token value is either the OAuth2 token or the
+            Personal Access Token (these are different types tokens
+            for gitlab, see
+            https://docs.gitlab.com/12.10/ee/api/README.html#authentication).
+            The `token` value should be `type:tokenstring` where
+            `type` is either `OAuth2` or `PAT` to indicate which type
+            of token is being specified.
+
+          Example `~/.config/nix/nix.conf`:
+
+          ```
+          personal-access-tokens = "github.com=23ac...b289 gitlab.mycompany.com=PAT:A123Bp_Cd..EfG gitlab.com=OAuth2:1jklw3jk"
+          ```
+
+          Example `~/code/flake.nix`:
+
+          ```nix
+          input.foo = {
+            type="gitlab";
+            host="gitlab.mycompany.com";
+            owner="mycompany";
+            repo="pro";
+          };
+          ```
+
+          This example specifies three tokens, one each for accessing
+          github.com, gitlab.mycompany.com, and sourceforge.net.
+
+          The `input.foo` uses the "gitlab" fetcher, which might
+          requires specifying the token type along with the token
+          value.
+          )"};
 
     Setting<Strings> experimentalFeatures{this, {}, "experimental-features",
         "Experimental Nix features to enable."};

--- a/src/libstore/globals.hh
+++ b/src/libstore/globals.hh
@@ -890,7 +890,7 @@ public:
           Example `~/.config/nix/nix.conf`:
 
           ```
-          personal-access-tokens = "github.com=23ac...b289 gitlab.mycompany.com=PAT:A123Bp_Cd..EfG gitlab.com=OAuth2:1jklw3jk"
+          access-tokens = "github.com=23ac...b289 gitlab.mycompany.com=PAT:A123Bp_Cd..EfG gitlab.com=OAuth2:1jklw3jk"
           ```
 
           Example `~/code/flake.nix`:

--- a/src/libstore/globals.hh
+++ b/src/libstore/globals.hh
@@ -861,7 +861,7 @@ public:
         )"};
 
     Setting<std::string> githubAccessToken{this, "", "github-access-token",
-        "GitHub access token to get access to GitHub data through the GitHub API for `github:<..>` flakes."};
+        "GitHub access token to get access to GitHub data through the GitHub API for `github:<..>` flakes (deprecated, please use 'access-tokens' instead)."};
 
     Setting<StringMap> accessTokens{this, {}, "access-tokens",
         R"(

--- a/src/libutil/config.cc
+++ b/src/libutil/config.cc
@@ -268,6 +268,26 @@ template<> std::string BaseSetting<StringSet>::to_string() const
     return concatStringsSep(" ", value);
 }
 
+template<> void BaseSetting<StringMap>::set(const std::string & str)
+{
+    auto kvpairs = tokenizeString<Strings>(str);
+    for (auto & s : kvpairs)
+    {
+        auto eq = s.find_first_of('=');
+        if (std::string::npos != eq)
+            value.emplace(std::string(s, 0, eq), std::string(s, eq + 1));
+        // else ignored
+    }
+}
+
+template<> std::string BaseSetting<StringMap>::to_string() const
+{
+    Strings kvstrs;
+    std::transform(value.begin(), value.end(), back_inserter(kvstrs),
+        [&](auto kvpair){ return kvpair.first + "=" + kvpair.second; });
+    return concatStringsSep(" ", kvstrs);
+}
+
 template class BaseSetting<int>;
 template class BaseSetting<unsigned int>;
 template class BaseSetting<long>;
@@ -278,6 +298,7 @@ template class BaseSetting<bool>;
 template class BaseSetting<std::string>;
 template class BaseSetting<Strings>;
 template class BaseSetting<StringSet>;
+template class BaseSetting<StringMap>;
 
 void PathSetting::set(const std::string & str)
 {


### PR DESCRIPTION
This builds upon the initial work done by @imalsogreg for adding GitHub and GitLab access token support to nix flake commands.  This work provides support for multiple different forge instances (e.g. gitlab.mycompany.com or github.fsf.org if such things existed) by:

1. Updating the nix.conf to have a single "access-tokens" configuration whose value is a space-separated list of host=token values.
2. When a host is identified, the list of access-tokens will be consulted to see if there is a token for that host.

This change also adds support for different types of access tokens.  For example, GitLab forges support both OAuth2 and Personal-Access tokens, and use different headers to provide those tokens in requests.